### PR TITLE
Make HTTP & QUIC listen on IPv6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 cmake_minimum_required(VERSION 3.13)
 
 project(oxenss
-    VERSION 2.11.1
+    VERSION 2.11.2
     LANGUAGES CXX C)
 
 set(CMAKE_CXX_STANDARD 20)

--- a/oxenss/daemon/command_line.cpp
+++ b/oxenss/daemon/command_line.cpp
@@ -169,14 +169,7 @@ parse_result parse_cli_args(int argc, char* argv[]) {
                "Deprecated port argument; use --https-port option instead")
             ->capture_default_str()
             ->type_name("PORT");
-    // TODO: need to support multiple here (e.g. so we can listen on public + lokinet)
-    cli.add_option(
-               "--bind-ip",
-               options.ip,
-               "IP address on which to listen for connections; typically this should be the "
-               "0.0.0.0 (the IPv4 \"any\" address)")
-            ->capture_default_str()
-            ->type_name("IP");
+    cli.add_option("--bind-ip", options.ip_ignored, "Deprecated and ignored.");
     cli.add_flag("--testnet", options.testnet, "Start storage server in testnet mode");
     cli.add_flag(
             "--force-start",

--- a/oxenss/daemon/command_line.h
+++ b/oxenss/daemon/command_line.h
@@ -8,7 +8,7 @@
 namespace oxenss::cli {
 
 struct command_line_options {
-    std::string ip = "0.0.0.0";
+    std::string ip_ignored = "0.0.0.0";
     uint16_t https_port = 22021;
     uint16_t omq_quic_port = 22020;
     std::string oxend_omq_rpc;  // Defaults to ipc://$HOME/.oxen/[testnet/]oxend.sock

--- a/oxenss/daemon/oxen-storage.cpp
+++ b/oxenss/daemon/oxen-storage.cpp
@@ -79,14 +79,6 @@ int main(int argc, char* argv[]) {
     // Always print version for the logs
     log::info(logcat, "{}", STORAGE_SERVER_VERSION_INFO);
 
-    if (options.ip == "127.0.0.1") {
-        log::critical(
-                logcat,
-                "Tried to bind oxen-storage to localhost, please bind "
-                "to outward facing address");
-        return EXIT_FAILURE;
-    }
-
     log::info(logcat, "Setting log level to {}", options.log_level);
     log::info(logcat, "Setting database location to {}", util::to_sv(options.data_dir.u8string()));
     log::info(logcat, "Connecting to oxend @ {}", options.oxend_omq_rpc);
@@ -171,7 +163,7 @@ int main(int argc, char* argv[]) {
                 service_node,
                 request_handler,
                 rate_limiter,
-                {{options.ip, options.https_port, true}},
+                {{"0.0.0.0", options.https_port, true}, {"::", options.https_port, true}},
                 ssl_cert,
                 ssl_key,
                 ssl_dh,
@@ -181,11 +173,13 @@ int main(int argc, char* argv[]) {
                 service_node,
                 request_handler,
                 rate_limiter,
-                oxen::quic::Address{options.ip, options.omq_quic_port},
+                std::array{
+                        oxen::quic::Address{"0.0.0.0", options.omq_quic_port},
+                        oxen::quic::Address{"::", options.omq_quic_port}},
                 ed_keys.sec);
         service_node.register_mq_server(quic.get());
 
-        auto http_client = std::make_shared<http::Client>(quic->loop());
+        auto http_client = std::make_shared<http::Client>(quic->loop);
         service_node.set_http_client(http_client);
         request_handler.set_http_client(http_client);
 
@@ -217,7 +211,8 @@ int main(int argc, char* argv[]) {
             std::this_thread::sleep_for(100ms);
 
         log::warning(logcat, "Received signal {}; shutting down...", signalled.load());
-        http_client.reset();  // Kills outgoing requests and prevents new ones
+        http_client.reset();  // Kills outgoing requests and prevents new ones.  Also depends on
+                              // `quic`'s event loop so *must* be destroyed before `quic`.
         service_node.shutdown();
         log::info(logcat, "Stopping https server");
         https_server.shutdown(true);

--- a/oxenss/daemon/oxen-storage.cpp
+++ b/oxenss/daemon/oxen-storage.cpp
@@ -187,11 +187,7 @@ int main(int argc, char* argv[]) {
                 l_keys};
 
         auto quic = std::make_unique<server::QUIC>(
-                service_node,
-                request_handler,
-                rate_limiter,
-                std::move(quic_bind),
-                ed_keys.sec);
+                service_node, request_handler, rate_limiter, std::move(quic_bind), ed_keys.sec);
         service_node.register_mq_server(quic.get());
 
         auto http_client = std::make_shared<http::Client>(quic->loop);

--- a/oxenss/daemon/oxen-storage.cpp
+++ b/oxenss/daemon/oxen-storage.cpp
@@ -159,11 +159,28 @@ int main(int argc, char* argv[]) {
 
         rpc::RateLimiter rate_limiter{*oxenmq_server};
 
+        std::vector<std::tuple<std::string, uint16_t, bool>> https_bind;
+        std::vector<oxen::quic::Address> quic_bind;
+#ifdef IPV6_V6ONLY
+        // If this define is set then listen in dual stack mode.  uWebSockets doesn't give us any
+        // way to disable this; for quic it's a flag on the address object.
+        https_bind.emplace_back("::", options.https_port, true);
+        quic_bind.emplace_back("::", options.omq_quic_port);
+        quic_bind.back().dual_stack = true;
+#else
+        https_bind.emplace_back("0.0.0.0", options.https_port, true);
+        https_bind.emplace_back("::", options.https_port, true);
+
+        quic_bind.emplace_back("0.0.0.0", options.omq_quic_port);
+        quic_bind.emplace_back("::", options.omq_quic_port);
+        quic_bind.back().dual_stack = false;
+#endif
+
         server::HTTPS https_server{
                 service_node,
                 request_handler,
                 rate_limiter,
-                {{"0.0.0.0", options.https_port, true}, {"::", options.https_port, true}},
+                std::move(https_bind),
                 ssl_cert,
                 ssl_key,
                 ssl_dh,
@@ -173,9 +190,7 @@ int main(int argc, char* argv[]) {
                 service_node,
                 request_handler,
                 rate_limiter,
-                std::array{
-                        oxen::quic::Address{"0.0.0.0", options.omq_quic_port},
-                        oxen::quic::Address{"::", options.omq_quic_port}},
+                std::move(quic_bind),
                 ed_keys.sec);
         service_node.register_mq_server(quic.get());
 

--- a/oxenss/http/http_client.cpp
+++ b/oxenss/http/http_client.cpp
@@ -21,8 +21,7 @@ struct curl_context {
     curl_context(Client& client, curl_socket_t fd) :
             client{client},
             sockfd{fd},
-            evt{event_new(client.loop->get_event_base(), sockfd, 0, Client::curl_perform_c, this)} {
-    }
+            evt{event_new(client.loop.get_event_base(), sockfd, 0, Client::curl_perform_c, this)} {}
     ~curl_context() {
         event_del(evt);
         event_free(evt);
@@ -92,7 +91,7 @@ int Client::handle_socket_c(
             event_del(curl_ctx->evt);
             event_assign(
                     curl_ctx->evt,
-                    client.loop->get_event_base(),
+                    client.loop.get_event_base(),
                     curl_ctx->sockfd,
                     events,
                     Client::curl_perform_c,
@@ -142,15 +141,14 @@ void Client::check_multi_info() {
     }
 }
 
-Client::Client(std::shared_ptr<oxen::quic::Loop> loop_) :
-        loop{std::move(loop_)},
+Client::Client(oxen::quic::Loop& loop_) :
+        loop{loop_},
         ev_timeout{evtimer_new(
-                loop->get_event_base(),
+                loop.get_event_base(),
                 [](evutil_socket_t /*fd*/, short /*events*/, void* arg) {
                     static_cast<Client*>(arg)->on_timeout();
                 },
                 this)} {
-    assert(loop);
     curl_multi = curl_multi_init();
     curl_multi_setopt(curl_multi, CURLMOPT_SOCKETDATA, this);
     curl_multi_setopt(curl_multi, CURLMOPT_SOCKETFUNCTION, Client::handle_socket_c);
@@ -159,7 +157,7 @@ Client::Client(std::shared_ptr<oxen::quic::Loop> loop_) :
 }
 
 Client::~Client() {
-    loop->call_get([this] {
+    loop.call_get([this] {
         alive.reset();
         for (auto& [session, cb] : active_reqs)
             curl_multi_remove_handle(curl_multi, session->GetCurlHolder()->handle);
@@ -196,10 +194,10 @@ void Client::post(
     sess->SetBody(std::move(payload));
     curl_easy_setopt(sess->GetCurlHolder()->handle, CURLOPT_PRIVATE, sess.get());
     sess->PreparePost();
-    loop->call([this,
-                alive = std::weak_ptr{alive},
-                sess = std::move(sess),
-                cb = std::move(cb)]() mutable {
+    loop.call([this,
+               alive = std::weak_ptr{alive},
+               sess = std::move(sess),
+               cb = std::move(cb)]() mutable {
         if (alive.expired())
             return;  // this got destroyed before we got into the call
         curl_multi_add_handle(curl_multi, sess->GetCurlHolder()->handle);

--- a/oxenss/http/http_client.h
+++ b/oxenss/http/http_client.h
@@ -21,7 +21,7 @@ class Client {
     using response_callback = std::function<void(cpr::Response r)>;
 
     // Starts a new client, attaching itself to the event loop and ready for requests.
-    explicit Client(std::shared_ptr<oxen::quic::Loop> loop);
+    explicit Client(oxen::quic::Loop& loop);
 
     // Non-copyable, non-movable
     Client(const Client&) = delete;
@@ -44,7 +44,7 @@ class Client {
             bool https_disable_validation = false);
 
   private:
-    std::shared_ptr<oxen::quic::Loop> loop;
+    oxen::quic::Loop& loop;
     event* ev_timeout;
     std::shared_ptr<const bool> alive = std::make_shared<bool>(true);
     CURLM* curl_multi;

--- a/oxenss/rpc/rate_limiter.cpp
+++ b/oxenss/rpc/rate_limiter.cpp
@@ -72,7 +72,7 @@ bool RateLimiter::should_rate_limit(
         return !remove_token(it->second, now, true);
 }
 
-bool RateLimiter::should_rate_limit_client(uint32_t ip, steady_clock::time_point now) {
+bool RateLimiter::should_rate_limit_client(const oxen::quic::ipv6& ip, steady_clock::time_point now) {
     std::lock_guard lock{mutex_};
 
     if (auto it = client_buckets_.find(ip); it != client_buckets_.end())
@@ -85,13 +85,6 @@ bool RateLimiter::should_rate_limit_client(uint32_t ip, steady_clock::time_point
     }
     client_buckets_.emplace(ip, TokenBucket{BUCKET_SIZE - 1, now});
     return false;
-}
-
-bool RateLimiter::should_rate_limit_client(
-        const std::string& ip_dotted_quad, steady_clock::time_point now) {
-    struct in_addr ip;
-    int res = inet_pton(AF_INET, ip_dotted_quad.c_str(), &ip);
-    return res == 1 ? should_rate_limit_client(ip.s_addr, now) : false;
 }
 
 void RateLimiter::clean_buckets(steady_clock::time_point now) {

--- a/oxenss/rpc/rate_limiter.cpp
+++ b/oxenss/rpc/rate_limiter.cpp
@@ -72,7 +72,8 @@ bool RateLimiter::should_rate_limit(
         return !remove_token(it->second, now, true);
 }
 
-bool RateLimiter::should_rate_limit_client(const oxen::quic::ipv6& ip, steady_clock::time_point now) {
+bool RateLimiter::should_rate_limit_client(
+        const oxen::quic::ipv6& ip, steady_clock::time_point now) {
     std::lock_guard lock{mutex_};
 
     if (auto it = client_buckets_.find(ip); it != client_buckets_.end())

--- a/oxenss/rpc/rate_limiter.h
+++ b/oxenss/rpc/rate_limiter.h
@@ -3,6 +3,7 @@
 #include <chrono>
 #include <cstdint>
 #include <mutex>
+#include <oxen/quic/ip.hpp>
 #include <unordered_map>
 
 #include <oxenss/crypto/keys.h>
@@ -14,6 +15,17 @@ class OxenMQ;
 /// https://en.wikipedia.org/wiki/Token_bucket
 
 namespace oxenss::rpc {
+
+// TODO: make oxen::quic::ipv6 should be std::hash-able
+struct addr_hash {
+    static inline constexpr size_t inverse_golden_ratio =
+            sizeof(size_t) >= 8 ? 0x9e37'79b9'7f4a'7c15 : 0x9e37'79b9;
+    size_t operator()(const oxen::quic::ipv6& addr) const noexcept {
+        auto h = std::hash<uint64_t>{}(addr.hi);
+        h ^= std::hash<uint64_t>{}(addr.lo) + inverse_golden_ratio + (h << 6) + (h >> 2);
+        return h;
+    }
+};
 
 class RateLimiter {
   public:
@@ -32,13 +44,7 @@ class RateLimiter {
             const crypto::legacy_pubkey& pubkey,
             std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now());
     bool should_rate_limit_client(
-            uint32_t ip,
-            std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now());
-
-    // Same as above, but takes a "a.b.c.d" string.  Returns false (i.e. don't rate limit) if
-    // the given address isn't parseable as an IPv4 address at all.
-    bool should_rate_limit_client(
-            const std::string& ip_dotted_quad,
+            const oxen::quic::ipv6& ip,
             std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now());
 
   private:
@@ -50,7 +56,7 @@ class RateLimiter {
     std::mutex mutex_;
 
     std::unordered_map<crypto::legacy_pubkey, TokenBucket> snode_buckets_;
-    std::unordered_map<uint32_t, TokenBucket> client_buckets_;
+    std::unordered_map<oxen::quic::ipv6, TokenBucket, addr_hash> client_buckets_;
 
     void clean_buckets(std::chrono::steady_clock::time_point now);
 };

--- a/oxenss/server/https.cpp
+++ b/oxenss/server/https.cpp
@@ -13,6 +13,7 @@
 #include <nlohmann/json.hpp>
 #include <oxenc/base64.h>
 #include <oxenc/endian.h>
+#include <oxen/quic/format.hpp>
 #include <oxenc/hex.h>
 #include <oxenmq/oxenmq.h>
 #include <variant>
@@ -423,25 +424,33 @@ void HTTPS::create_endpoints(uWS::SSLApp& https) {
     });
 }
 
-bool HTTPS::should_rate_limit_client(std::string_view addr) {
-    if (addr.size() != 4)
-        return true;
-    uint32_t ip;
-    std::memcpy(&ip, addr.data(), 4);
-    oxenc::big_to_host_inplace(ip);
-    return rate_limiter_.should_rate_limit_client(ip);
-}
-
 void HTTPS::process_storage_rpc_req(HttpRequest& req, HttpResponse& res) {
     auto addr = res.getRemoteAddress();
-    if (addr.size() != 4) {
-        // We don't (currently?) support IPv6 at all (SS published IPs are only IPv4) so if we
-        // somehow get an IPv6 address then it isn't a proper SS request so just drop it.
-        log::warning(logcat, "incoming client request is not IPv4; dropping it");
+    oxen::quic::ipv6 ip;
+    if (addr.size() == 4) {
+        // IPv4: convert to ipv4-mapped-ipv6:
+        ip = oxen::quic::ipv6{
+                0,
+                0,
+                0,
+                0,
+                0,
+                0xffff,
+                oxenc::load_big_to_host<uint16_t>(addr.data()),
+                oxenc::load_big_to_host<uint16_t>(addr.data() + 2)};
+    } else if (addr.size() == 16) {
+        ip = oxen::quic::ipv6{
+                std::span<const uint8_t, 16>{reinterpret_cast<const uint8_t*>(addr.data()), 16}};
+    } else {
+        log::warning(
+                logcat,
+                "Invalid incoming request IP: '{}'; rejecting request",
+                oxenc::to_hex(addr));
         return error_response(res, http::BAD_REQUEST);
     }
-    if (should_rate_limit_client(addr)) {
-        log::debug(logcat, "Rate limiting client request from {}", get_remote_address(res));
+
+    if (rate_limiter_.should_rate_limit_client(ip)) {
+        log::debug(logcat, "Rate limiting client request from {}", ip);
         return error_response(res, http::TOO_MANY_REQUESTS);
     }
     if (!req.getHeader("x-loki-long-poll").empty()) {

--- a/oxenss/server/https.h
+++ b/oxenss/server/https.h
@@ -90,8 +90,6 @@ class HTTPS {
 
     void create_endpoints(uWS::SSLApp& http);
 
-    bool should_rate_limit_client(std::string_view addr);
-
     void process_storage_rpc_req(HttpRequest& req, HttpResponse& res);
     void process_onion_req_v2(HttpRequest& req, HttpResponse& res);
 

--- a/oxenss/server/mqbase.cpp
+++ b/oxenss/server/mqbase.cpp
@@ -5,6 +5,7 @@
 #include "utils.h"
 #include <fmt/ranges.h>
 #include <oxenc/hex.h>
+#include <oxen/quic/format.hpp>
 
 namespace oxenss::server {
 
@@ -174,7 +175,7 @@ void MQBase::handle_monitor_message_single(
 bool MQBase::handle_client_rpc(
         std::string_view name,
         std::string_view params,
-        const std::string& remote_addr,
+        std::optional<oxen::quic::ipv6> remote_ip,
         std::function<void(http::response_code, std::string_view)> reply,
         bool forwarded) {
     // Check client rpc endpoints
@@ -184,8 +185,9 @@ bool MQBase::handle_client_rpc(
 
     auto& handler = it->second.mq;
 
-    if (!forwarded && rate_limiter_->should_rate_limit_client(remote_addr)) {
-        log::debug(logcat, "Rate limiting client request from {}", remote_addr);
+    if (!forwarded && (!remote_ip || rate_limiter_->should_rate_limit_client(*remote_ip))) {
+        if (remote_ip)
+            log::debug(logcat, "Rate limiting client request from {}", *remote_ip);
         reply(http::TOO_MANY_REQUESTS, "Too many requests, try again later"sv);
         return true;
     }

--- a/oxenss/server/mqbase.h
+++ b/oxenss/server/mqbase.h
@@ -32,7 +32,8 @@ struct message;
 namespace oxenss::server {
 
 // For oxenmq: the connection id; for quic: pair of {endpoint_index, endpoint_connectionid}
-using connection_id = std::variant<oxenmq::ConnectionID, std::pair<size_t, oxen::quic::ConnectionID>>;
+using connection_id =
+        std::variant<oxenmq::ConnectionID, std::pair<size_t, oxen::quic::ConnectionID>>;
 
 using namespace std::literals;
 

--- a/oxenss/server/mqbase.h
+++ b/oxenss/server/mqbase.h
@@ -31,7 +31,8 @@ struct message;
 
 namespace oxenss::server {
 
-using connection_id = std::variant<oxenmq::ConnectionID, oxen::quic::ConnectionID>;
+// For oxenmq: the connection id; for quic: pair of {endpoint_index, endpoint_connectionid}
+using connection_id = std::variant<oxenmq::ConnectionID, std::pair<size_t, oxen::quic::ConnectionID>>;
 
 using namespace std::literals;
 

--- a/oxenss/server/mqbase.h
+++ b/oxenss/server/mqbase.h
@@ -73,7 +73,7 @@ class MQBase {
     bool handle_client_rpc(
             std::string_view name,
             std::string_view params,
-            const std::string& remote_addr,
+            std::optional<oxen::quic::ipv6> remote_addr,
             std::function<void(http::response_code status, std::string_view body)> reply,
             bool forwarded = false);
 

--- a/oxenss/server/omq.cpp
+++ b/oxenss/server/omq.cpp
@@ -156,10 +156,32 @@ void OMQ::handle_client_request(std::string_view method, oxenmq::Message& messag
         return;
     }
 
+    std::optional<oxen::quic::ipv6> remote_ip;
+    if (!forwarded) {
+        try {
+            // Currently oxenmq only listens for public client rpc on IPv4 public addresses, so if
+            // we get something else here we just reject the request.
+            oxen::quic::ipv4 ipv4{message.remote};
+            auto ipv4_hi = static_cast<uint16_t>(ipv4.addr >> 16);
+            auto ipv4_lo = static_cast<uint16_t>(ipv4.addr & 0xffff);
+            remote_ip.emplace(0, 0, 0, 0, 0, 0xffff, ipv4_hi, ipv4_lo);
+        } catch (const std::exception& e) {
+            log::warning(logcat, "Rejecting non-ipv4 OMQ RPC request from {}", message.remote);
+            message.send_reply(
+                    std::to_string(http::BAD_REQUEST.first),
+                    fmt::format(
+                            "Invalid request: non-forwarded OMQ client RPC requests are only "
+                            "permitted via IPv4",
+                            full_size,
+                            message.data.size()));
+            return;
+        }
+    }
+
     [[maybe_unused]] bool found = handle_client_rpc(
             method,
             message.data.size() == full_size ? message.data.back() : ""sv,
-            message.remote,
+            std::move(remote_ip),
             [send = message.send_later()](http::response_code status, std::string_view body) {
                 if (status == http::OK)
                     send.reply(body);

--- a/oxenss/server/quic.cpp
+++ b/oxenss/server/quic.cpp
@@ -37,21 +37,28 @@ QUIC::QUIC(
         snode::ServiceNode& snode,
         rpc::RequestHandler& rh,
         rpc::RateLimiter& rl,
-        const Address& bind,
+        std::span<const Address> bind,
         const crypto::ed25519_seckey& sk) :
-        local{bind},
-        tls_creds{quic::GNUTLSCreds::make_from_ed_seckey(sk.str())},
-        request_handler{rh},
-        command_handler{[this](quic::message m) {
-            handle_request(std::make_shared<quic::message>(std::move(m)));
-        }} {
+        tls_creds{quic::GNUTLSCreds::make_from_ed_seckey(sk.str())}, request_handler{rh} {
     service_node_ = &snode;
     request_handler_ = &rh;
     rate_limiter_ = &rl;
 
     static_cast<quic::GNUTLSCreds*>(tls_creds.get())->enable_inbound_0rtt();
 
-    ep = network.endpoint(local, make_endpoint_static_secret(sk), quic::opt::alpns{ALPN});
+    if (bind.empty())
+        throw std::invalid_argument{"No bind addresses given to QUIC listener!"};
+
+    endpoints.reserve(bind.size());
+    for (auto& a : bind) {
+        endpoints.push_back(quic::Endpoint::endpoint(
+                loop, a, make_endpoint_static_secret(sk), quic::opt::alpns{ALPN}));
+        if (!reach_ep && a.is_ipv4())
+            reach_ep = endpoints.back().get();
+    }
+
+    if (!reach_ep)
+        throw std::invalid_argument{"No IPv4 bind address given to QUIC listener!"};
 
     // Add a category to OMQ for handling incoming quic request jobs
     service_node_->omq_server()->add_category(
@@ -63,37 +70,43 @@ QUIC::QUIC(
 }
 
 void QUIC::startup_endpoint() {
-    ep->listen(
-            tls_creds,
-            // Stream constructor: all incoming streams become BTRequestStreams, allowing clients to
-            // use multiple streams to send higher/lower priority data in parallel by juggling
-            // streams.
-            [this](quic::Connection& c, quic::Endpoint& e, std::optional<int64_t>) {
-                return e.loop.make_shared<quic::BTRequestStream>(c, e, command_handler);
-            });
+    size_t ep_idx = 0;
+    for (auto& ep : endpoints) {
+        auto handler = [this, ep_idx](quic::message m) { handle_request(std::move(m), ep_idx); };
+        ep->listen(
+                tls_creds,
+                // Stream constructor: all incoming streams become BTRequestStreams, allowing
+                // clients to use multiple streams to send higher/lower priority data in parallel by
+                // juggling streams.
+                [handler = std::move(handler)](
+                        quic::Connection& c, quic::Endpoint& e, std::optional<int64_t>) {
+                    return e.loop.make_shared<quic::BTRequestStream>(c, e, handler);
+                });
+        ep_idx++;
+    }
 }
 
-void QUIC::handle_monitor_message(std::shared_ptr<quic::message> msg) {
+void QUIC::handle_monitor_message(quic::message msg, size_t ep_idx) {
 
-    auto body = msg->body();
-    auto refid = msg->stream()->reference_id;
+    auto body = msg.body();
+    auto refid = msg.stream()->reference_id;
     handle_monitor(
             body,
-            [msg = std::move(msg)](std::string response) { msg->respond(std::move(response)); },
-            refid);
+            [msg = std::move(msg)](std::string response) { msg.respond(std::move(response)); },
+            std::pair{ep_idx, refid});
 }
 
-void QUIC::handle_ping(std::shared_ptr<quic::message> msg) {
+void QUIC::handle_ping(quic::message msg) {
     log::debug(logcat, "Remote pinged me");
     service_node_->update_last_ping(snode::ReachType::QUIC);
-    msg->respond("pong");
+    msg.respond("pong");
 }
 
-void QUIC::handle_request(std::shared_ptr<quic::message> msg) {
+void QUIC::handle_request(quic::message msg, size_t ep_idx) {
     auto& omq = *service_node_->omq_server();
-    auto remote_host = msg->stream()->get_conn()->remote().host();
+    auto remote_host = msg.stream()->get_conn()->remote().host();
 
-    auto name = msg->endpoint();
+    auto name = msg.endpoint();
     if (!(name == "snode_ping" || name == "monitor" || name == "onion_req" ||
           rpc::RequestHandler::client_rpc_endpoints.count(name)))
         throw quic::no_such_endpoint{};
@@ -102,34 +115,37 @@ void QUIC::handle_request(std::shared_ptr<quic::message> msg) {
     // `sn_mutex_` we could deadlock (because the `open_stream` we do in reachability testing is
     // synchronous, but is also called with the `sn_mutex_` held).
     omq.inject_task(
-            "quic", "quic:{}"_format(msg->endpoint()), remote_host, [this, msg, remote_host] {
-                auto name = msg->endpoint();
+            "quic",
+            "quic:{}"_format(msg.endpoint()),
+            remote_host,
+            [this, msg, remote_host, ep_idx] {
+                auto name = msg.endpoint();
 
                 if (name == "snode_ping")
                     handle_ping(std::move(msg));
 
                 if (name == "monitor")
-                    handle_monitor_message(std::move(msg));
+                    handle_monitor_message(std::move(msg), ep_idx);
 
                 if (name == "onion_req")
                     handle_onion_request(std::move(msg));
 
                 handle_client_rpc(
                         name,
-                        msg->body(),
+                        msg.body(),
                         remote_host,
                         [msg](http::response_code code, std::string_view res_body) {
                             if (code.first == http::OK.first)
-                                msg->respond(res_body);
+                                msg.respond(res_body);
                             else
-                                msg->respond(
+                                msg.respond(
                                         "{} {}\n\n{}"_format(code.first, code.second, res_body),
                                         true);
                         });
             });
 }
 
-void QUIC::handle_onion_request(std::shared_ptr<quic::message> msg) {
+void QUIC::handle_onion_request(quic::message msg) {
 
     auto started = std::chrono::steady_clock::now();
     try {
@@ -155,17 +171,17 @@ void QUIC::handle_onion_request(std::shared_ptr<quic::message> msg) {
                     }
 
                     if (res.status.first != http::OK.first)
-                        msg->respond(
+                        msg.respond(
                                 "{} {}\n\n{}"_format(res.status.first, res.status.second, body),
                                 true);
                     else
-                        msg->respond(body);
+                        msg.respond(body);
                 },
                 0,  // hopno
                 crypto::EncryptType::aes_gcm,
         };
 
-        auto [ciphertext, json_req] = rpc::parse_combined_payload(msg->body());
+        auto [ciphertext, json_req] = rpc::parse_combined_payload(msg.body());
 
         onion.ephem_key = rpc::extract_x25519_from_hex(
                 json_req.at("ephemeral_key").get_ref<const std::string&>());
@@ -185,7 +201,7 @@ void QUIC::handle_onion_request(std::shared_ptr<quic::message> msg) {
     } catch (const std::exception& e) {
         auto err = fmt::format("Error parsing onion request: {}", e.what());
         log::error(logcat, "{}", err);
-        msg->respond(
+        msg.respond(
                 "{} {}\n\n{}"_format(http::BAD_REQUEST.first, http::BAD_REQUEST.second, err), true);
     }
 }
@@ -203,11 +219,15 @@ nlohmann::json QUIC::wrap_response(
 }
 
 void QUIC::notify(std::vector<connection_id>& conns, std::string_view notification) {
-    for (const auto& c : conns)
-        if (auto* cid = std::get_if<quic::ConnectionID>(&c))
-            if (auto conn = ep->get_conn(*cid))
+    for (const auto& c : conns) {
+        if (auto* quic_id = std::get_if<std::pair<size_t, quic::ConnectionID>>(&c)) {
+            auto& [ep_idx, cid] = *quic_id;
+            assert(ep_idx < endpoints.size());
+            if (auto conn = endpoints[ep_idx]->get_conn(cid))
                 if (auto str = conn->get_stream<quic::BTRequestStream>(0))
                     str->command("notify", notification);
+        }
+    }
 }
 
 void QUIC::reachability_test(std::shared_ptr<snode::sn_test> test) {
@@ -219,7 +239,7 @@ void QUIC::reachability_test(std::shared_ptr<snode::sn_test> test) {
         return;
     const auto& ct = *maybe_ct;
 
-    auto conn = ep->connect(
+    auto conn = reach_ep->connect(
             {ct.pubkey_ed25519.view(), ct.ip, ct.omq_quic_port},
             tls_creds,
             quic::opt::handshake_timeout{5s});

--- a/oxenss/server/quic.cpp
+++ b/oxenss/server/quic.cpp
@@ -53,7 +53,7 @@ QUIC::QUIC(
     for (auto& a : bind) {
         endpoints.push_back(quic::Endpoint::endpoint(
                 loop, a, make_endpoint_static_secret(sk), quic::opt::alpns{ALPN}));
-        if (!reach_ep && a.is_ipv4())
+        if (!reach_ep && (a.is_ipv4() || (a.is_any_addr() && a.dual_stack)))
             reach_ep = endpoints.back().get();
     }
 
@@ -104,7 +104,9 @@ void QUIC::handle_ping(quic::message msg) {
 
 void QUIC::handle_request(quic::message msg, size_t ep_idx) {
     auto& omq = *service_node_->omq_server();
-    auto remote_host = msg.stream()->get_conn()->remote().host();
+    auto remote_host = msg.stream()->get_conn()->remote();
+    auto remote_ip =
+            (remote_host.is_ipv4() ? remote_host.mapped_ipv4_as_ipv6() : remote_host).to_ipv6();
 
     auto name = msg.endpoint();
     if (!(name == "snode_ping" || name == "monitor" || name == "onion_req" ||
@@ -117,8 +119,8 @@ void QUIC::handle_request(quic::message msg, size_t ep_idx) {
     omq.inject_task(
             "quic",
             "quic:{}"_format(msg.endpoint()),
-            remote_host,
-            [this, msg, remote_host, ep_idx] {
+            remote_host.host(),
+            [this, msg, remote_ip, ep_idx] {
                 auto name = msg.endpoint();
 
                 if (name == "snode_ping")
@@ -133,7 +135,7 @@ void QUIC::handle_request(quic::message msg, size_t ep_idx) {
                 handle_client_rpc(
                         name,
                         msg.body(),
-                        remote_host,
+                        remote_ip,
                         [msg](http::response_code code, std::string_view res_body) {
                             if (code.first == http::OK.first)
                                 msg.respond(res_body);

--- a/oxenss/server/quic.h
+++ b/oxenss/server/quic.h
@@ -8,7 +8,8 @@
 #include <oxenss/rpc/rate_limiter.h>
 #include <oxenss/snode/service_node.h>
 
-#include <oxen/quic.hpp>
+#include <oxen/quic/btstream.hpp>
+#include <oxen/quic/endpoint.hpp>
 
 namespace oxenss::rpc {
 class RequestHandler;
@@ -40,7 +41,7 @@ class QUIC : public MQBase {
     QUIC(snode::ServiceNode& snode,
          rpc::RequestHandler& rh,
          rpc::RateLimiter& rl,
-         const Address& bind,
+         std::span<const Address> bind,
          const crypto::ed25519_seckey& sk);
 
     void startup_endpoint();
@@ -49,29 +50,24 @@ class QUIC : public MQBase {
 
     void reachability_test(std::shared_ptr<snode::sn_test> test) override;
 
-    oxen::quic::Network& net() { return network; }
-
-    const std::shared_ptr<quic::Loop>& loop() const { return loop_; }
+    quic::Loop loop{};
 
   private:
-    const Address local;
-    std::shared_ptr<quic::Loop> loop_ = std::make_shared<quic::Loop>();
-    quic::Network network{loop_};
     std::shared_ptr<quic::TLSCreds> tls_creds;
-    std::shared_ptr<quic::Endpoint> ep;
+    std::vector<std::shared_ptr<quic::Endpoint>> endpoints;
+    quic::Endpoint* reach_ep = nullptr;
 
     rpc::RequestHandler& request_handler;
-    std::function<void(quic::message m)> command_handler;
 
     std::shared_ptr<quic::Endpoint> create_endpoint();
 
-    void handle_request(std::shared_ptr<quic::message> msg);
+    void handle_request(quic::message msg, size_t ep_idx);
 
-    void handle_onion_request(std::shared_ptr<quic::message> msg);
+    void handle_onion_request(quic::message msg);
 
-    void handle_monitor_message(std::shared_ptr<quic::message> msg);
+    void handle_monitor_message(quic::message msg, size_t ep_idx);
 
-    void handle_ping(std::shared_ptr<quic::message> msg);
+    void handle_ping(quic::message msg);
 
     nlohmann::json wrap_response(
             [[maybe_unused]] const http::response_code& status,

--- a/unit_test/rate_limiter.cpp
+++ b/unit_test/rate_limiter.cpp
@@ -58,10 +58,22 @@ TEST_CASE("rate limiter - snode - multiple identifiers", "[ratelim][snode]") {
     CHECK_FALSE(rate_limiter.should_rate_limit(identifier2, now));
 }
 
+oxen::quic::ipv6 map_ipv4(uint8_t a, uint8_t b, uint8_t c, uint8_t d) {
+    return oxen::quic::ipv6{
+            0,
+            0,
+            0,
+            0,
+            0,
+            0xffff,
+            static_cast<uint16_t>((a << 8) | b),
+            static_cast<uint16_t>((c << 8) | d)};
+}
+
 TEST_CASE("rate limiter - client - empty bucket", "[ratelim][client]") {
     oxenmq::OxenMQ omq;
     RateLimiter rate_limiter{omq};
-    uint32_t identifier = (10 << 24) + (1 << 16) + (1 << 8) + 13;
+    auto identifier = map_ipv4(10, 1, 1, 13);
     const auto now = std::chrono::steady_clock::now();
 
     for (size_t i = 0; i < RateLimiter::BUCKET_SIZE; ++i) {
@@ -77,7 +89,7 @@ TEST_CASE("rate limiter - client - empty bucket", "[ratelim][client]") {
 TEST_CASE("rate limiter - client - steady bucket fillup", "[ratelim][client]") {
     oxenmq::OxenMQ omq;
     RateLimiter rate_limiter{omq};
-    uint32_t identifier = (10 << 24) + (1 << 16) + (1 << 8) + 13;
+    auto identifier = map_ipv4(10, 1, 1, 13);
     const auto now = std::chrono::steady_clock::now();
     // make requests at the same rate as the bucket is filling up
     for (size_t i = 0; i < RateLimiter::BUCKET_SIZE * 10; ++i) {
@@ -89,7 +101,7 @@ TEST_CASE("rate limiter - client - steady bucket fillup", "[ratelim][client]") {
 TEST_CASE("rate limiter - client - multiple identifiers", "[ratelim][client]") {
     oxenmq::OxenMQ omq;
     RateLimiter rate_limiter{omq};
-    uint32_t identifier1 = (10 << 24) + (1 << 16) + (1 << 8) + 13;
+    auto identifier1 = map_ipv4(10, 1, 1, 13);
     const auto now = std::chrono::steady_clock::now();
 
     for (size_t i = 0; i < RateLimiter::BUCKET_SIZE; ++i) {
@@ -97,7 +109,7 @@ TEST_CASE("rate limiter - client - multiple identifiers", "[ratelim][client]") {
     }
     CHECK(rate_limiter.should_rate_limit_client(identifier1, now));
 
-    uint32_t identifier2 = (10 << 24) + (1 << 16) + (1 << 8) + 10;
+    auto identifier2 = map_ipv4(10, 1, 1, 10);
     // other id
     CHECK_FALSE(rate_limiter.should_rate_limit_client(identifier2, now));
 }
@@ -107,14 +119,15 @@ TEST_CASE("rate limiter - client - max client limit", "[ratelim][client]") {
     RateLimiter rate_limiter{omq};
     const auto now = std::chrono::steady_clock::now();
 
-    uint32_t ip_start = (10 << 24) + 1;
+    auto ip = map_ipv4(10, 0, 0, 1);
 
     for (uint32_t i = 0; i < RateLimiter::MAX_CLIENTS; ++i) {
-        rate_limiter.should_rate_limit_client(ip_start + i, now);
+        ip = ip.next_ip().value();
+        rate_limiter.should_rate_limit_client(ip, now);
     }
-    uint32_t overflow_ip = ip_start + RateLimiter::MAX_CLIENTS;
-    CHECK(rate_limiter.should_rate_limit_client(overflow_ip, now));
+    ip = ip.next_ip().value();
+    CHECK(rate_limiter.should_rate_limit_client(ip, now));
     // Wait for buckets to be filled
     const auto delta = 1'000'000us / RateLimiter::TOKEN_RATE;
-    CHECK_FALSE(rate_limiter.should_rate_limit_client(overflow_ip, now + delta));
+    CHECK_FALSE(rate_limiter.should_rate_limit_client(ip, now + delta));
 }


### PR DESCRIPTION
The upcoming Session Router 1.0.2 starts using IPv6 for internal network connections (i.e. client-to-client, and client-to-snode), but currently storage server only listens on the IPv4 any address (0.0.0.0). This PR makes it also listen on the IPv6 any address (::) so requests via Session Router will work with IPv6 connections.

Note that this does not require or make use of public IPv6 connectivity for storage servers: this is only to allow a Session Router client (such as a Session app) to speak to a Session Router through the internal private range IPv6-enabled tunnel.