### PR TITLE
Fix missing namespace on bulk message serialization

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -195,7 +195,7 @@ local static_check_and_upload = [
   // Various debian builds
   debian_pipeline('Debian (amd64)', docker_base + 'debian-sid', lto=true),
   debian_pipeline('Debian Debug (amd64)', docker_base + 'debian-sid', build_type='Debug'),
-  clang(17, lto=true),
+  clang(19, lto=true),
   debian_pipeline('Debian stable (i386)', docker_base + 'debian-stable/i386', werror=false),
   debian_pipeline('Ubuntu LTS (amd64)', docker_base + 'ubuntu-lts', oxen_repo=true),
   debian_pipeline('Ubuntu latest (amd64)', docker_base + 'ubuntu-rolling'),

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 cmake_minimum_required(VERSION 3.13)
 
 project(oxenss
-    VERSION 2.11.2
+    VERSION 2.11.3
     LANGUAGES CXX C)
 
 set(CMAKE_CXX_STANDARD 20)

--- a/oxenss/snode/serialization.cpp
+++ b/oxenss/snode/serialization.cpp
@@ -9,6 +9,7 @@
 #include <oxenc/bt_serialize.h>
 
 #include <chrono>
+#include <type_traits>
 
 namespace oxenss::snode {
 
@@ -46,6 +47,7 @@ static std::pair<std::string, bool> serialize_more_messages(
         item.append(to_epoch_ms(msg->timestamp));
         item.append(to_epoch_ms(msg->expiry));
         item.append(msg->data);
+        item.append(to_int(msg->msg_namespace));
     }
 
     if (some) {
@@ -108,6 +110,12 @@ std::vector<message> deserialize_messages(std::string_view slice) {
         item.timestamp = from_epoch_ms(m.consume_integer<int64_t>());
         item.expiry = from_epoch_ms(m.consume_integer<int64_t>());
         item.data = m.consume_string();
+        // TODO: the namespace was missing before 2.11.3, so for now we only load it if there is an
+        // extra field in the list.  Once all storage servers are running 2.11.3+ we can remove this
+        // `if` and just require the field unconditionally:
+        if (!m.is_finished())
+            item.msg_namespace = static_cast<namespace_id>(
+                    m.consume_integer<std::underlying_type_t<namespace_id>>());
     }
 
     log::trace(logcat, "=== END ===");

--- a/unit_test/serialization.cpp
+++ b/unit_test/serialization.cpp
@@ -17,7 +17,7 @@ TEST_CASE("v1 serialization - basic values", "[serialization]") {
     const std::chrono::system_clock::time_point timestamp{12'345'678ms};
     const auto expiry = timestamp + 3456s;
     std::vector<oxenss::message> msgs;
-    msgs.emplace_back(pub_key, hash, oxenss::namespace_id::Default, timestamp, expiry, data);
+    msgs.emplace_back(pub_key, hash, oxenss::namespace_id::UserProfile, timestamp, expiry, data);
     auto serialized = serialize_messages(msgs.begin(), msgs.end(), 1);
     REQUIRE(serialized.size() == 1);
     const auto expected_serialized =
@@ -28,6 +28,7 @@ TEST_CASE("v1 serialization - basic values", "[serialization]") {
             "i12345678e"              // timestamp
             "i15801678e"              // expiry
             "5:da\x00ta"              // data
+            "i2e"                     // namespace
             "e"s;
     CHECK(serialized.front() == "\x01l"s + expected_serialized + "e");
 
@@ -44,6 +45,7 @@ TEST_CASE("v1 serialization - basic values", "[serialization]") {
         CHECK(messages[i].hash == hash);
         CHECK(messages[i].timestamp == timestamp);
         CHECK(messages[i].expiry == expiry);
+        CHECK(messages[i].msg_namespace == oxenss::namespace_id::UserProfile);
     }
 }
 
@@ -56,7 +58,7 @@ TEST_CASE("v1 serialization - batch serialization", "[serialization]") {
     const auto ttl = 24h;
     std::vector<oxenss::message> msgs;
     msgs.emplace_back(
-            pub_key, hash, oxenss::namespace_id::Default, timestamp, timestamp + ttl, data);
+            pub_key, hash, oxenss::namespace_id::GroupInfo, timestamp, timestamp + ttl, data);
     auto serialized = serialize_messages(msgs.begin(), msgs.end(), 1);
     REQUIRE(serialized.size() == 1);
     auto first = serialized.front();


### PR DESCRIPTION
When performing bulk serializing between SNs (which happens when a new node joins a swarm), the message namespace was not being included and so the receiving node would end up putting all bulk filled messages into namespace 0, where they would then be ignored.

This fixes it to include the namespace as an extra field in the serialization and to consume it if present.

This can be introduced without worrying about breaking older clients because existing nodes only read the first entries of the list and ignore any trailing items, and so this will properly get the namespace when the two sides are both upgraded without breaking.  (New clients for now only consume the namespace if it was included).